### PR TITLE
User data encryption

### DIFF
--- a/includes/class-quiz-handler.php
+++ b/includes/class-quiz-handler.php
@@ -123,30 +123,26 @@ class Quiz_Handler {
             //If personal info is provided, save user data
             if ($personal_info !== null) {
                 $user_data = array(
-                    'first_name' => sanitize_text_field($personal_info[23]),
-                    'last_name' => sanitize_text_field($personal_info[30]),
-                    'email' => sanitize_email($personal_info[28]),
+                    'first_name' => $this->quiz_encrypt_data(sanitize_text_field($personal_info[23])),
+                    'last_name' => $this->quiz_encrypt_data(sanitize_text_field($personal_info[30])),
+                    'email' => $this->quiz_encrypt_data(sanitize_email($personal_info[28])),
                     'dob' => $personal_info[24],
-                    'province' => $personal_info[25],
-                    'phone_number' => sanitize_text_field($personal_info[29]),
-                    'gender' => $personal_info[31],
+                    'province' => $this->quiz_encrypt_data($personal_info[25]),
+                    'phone_number' => $this->quiz_encrypt_data(sanitize_text_field($personal_info[29])),
+                    'gender' => $this->quiz_encrypt_data($personal_info[31]),
                     'password_hash' => password_hash($personal_info[40], PASSWORD_DEFAULT) ?? "",
-                    'user_type' => 'senior'
+                    'user_type' => 'senior',
+                    'blind_index' => $this->quiz_generate_blind_index(sanitize_email($personal_info[28]), sanitize_text_field($personal_info[30]), sanitize_text_field($personal_info[29]))
                 );
 
                 //Check if user already exists in database, existing_user will be Null if no user with important fields is found
+                // With the encrypted data, the hash of the search inputs is compared to the hash of those fields when creating a user
                 $existing_user = $this->wpdb->get_row($this->wpdb->prepare(
                     "SELECT user_id 
                      FROM {$this->tables['users']} 
-                     WHERE UPPER(last_name) = UPPER(%s) 
-                     AND UPPER(email) = UPPER(%s)
-                     AND phone_number = %s
-                     AND password_hash = %s
+                     WHERE blind_index = %s
                      AND user_type = 'senior'",
-                    $user_data['last_name'],
-                    $user_data['email'],
-                    $user_data['phone_number'],
-                    $user_data['password_hash']
+                    $user_data['blind_index']
                 ));
                 
                 //Previous user found
@@ -160,7 +156,7 @@ class Quiz_Handler {
                     $user_insert_result = $this->wpdb->insert(
                         $this->tables['users'],
                         $user_data,
-                        array('%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s')
+                        array('%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s', '%s')
                     );
 
                     //User creation in database failed
@@ -349,6 +345,62 @@ class Quiz_Handler {
             array('%d', '%d', '%d'),
             array('%d')
         );
+    }
+
+    public function quiz_encrypt_data(string $field): string|false {
+        if (!file_exists(PRIVATE_KEY)) {
+            error_log("Encryption key file not found");
+            return false;
+        }
+        $key_b64 = trim(file_get_contents(PRIVATE_KEY));
+        $key = sodium_base642bin($key_b64, SODIUM_BASE64_VARIANT_ORIGINAL); // Decode the key
+        $nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES); // Generate a different 24-bit nonce for every message
+        $encrypted = sodium_crypto_secretbox($field, $nonce, $key); // The actual encryption
+        $encrypted_b64 = sodium_bin2base64($nonce . $encrypted, SODIUM_BASE64_VARIANT_ORIGINAL); // Base64 of nonce + encrypted message
+
+        // Clear out the memory
+        sodium_memzero($field);
+        sodium_memzero($nonce);
+        sodium_memzero($key_b64);
+        sodium_memzero($key);
+
+        return $encrypted_b64;
+    }
+
+    // Not used anywhere yet
+    public function quiz_decrypt_data(string $encrypted_field): string|false {
+        if (!file_exists(PRIVATE_KEY)) {
+            error_log("Encryption key file not found");
+            return false;
+        }
+        $key_b64 = trim(file_get_contents(PRIVATE_KEY));
+        $key = sodium_base642bin($key_b64, SODIUM_BASE64_VARIANT_ORIGINAL);
+        $decoded_field = sodium_base642bin($encrypted_field, SODIUM_BASE64_VARIANT_ORIGINAL);
+        $nonce = mb_substr($decoded_field, 0, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES, '8bit');
+        $encrypted_text = mb_substr($decoded_field, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES, null, '8bit');
+        $field_text = sodium_crypto_secretbox_open($encrypted_text, $nonce, $key);
+
+        sodium_memzero($nonce);
+        sodium_memzero($key_b64);
+        sodium_memzero($key);
+
+        return $field_text;
+    }
+
+    public function quiz_generate_blind_index(string $email, string $last_name, string $phone_number): string|false {
+        $combined = $email . $last_name . $phone_number;
+        if (!file_exists(BLIND_INDEX_KEY)) {
+            error_log("Blind index key file not found");
+            return false;
+        }
+        $key_b64 = trim(file_get_contents(BLIND_INDEX_KEY));
+        $key = sodium_base642bin($key_b64, SODIUM_BASE64_VARIANT_ORIGINAL);
+        $blind_index = sodium_crypto_auth($combined, $key);
+        $blind_index_b64 = sodium_bin2base64($blind_index, SODIUM_BASE64_VARIANT_ORIGINAL);
+
+        sodium_memzero($key_b64);
+        sodium_memzero($key);
+        return $blind_index_b64;
     }
 }
 

--- a/includes/class-quiz-search.php
+++ b/includes/class-quiz-search.php
@@ -27,21 +27,16 @@ class Quiz_Search {
     //Using given identifying info, this function finds all matching quiz rows
     public function search_quizzes($last_name, $email, $phone_number, $password) {
 
-        //Convert to upper to negate case sensitivity
-        $last_name = strtoupper($last_name);
-        $email = strtoupper($email);
+        $quiz_handler = new Quiz_Handler();
+        $blind_index = $quiz_handler->quiz_generate_blind_index($email, $last_name, $phone_number);
 
         //Find the user using provided info
         $user = $this->wpdb->get_row($this->wpdb->prepare(
             "SELECT user_id, password_hash
              FROM {$this->tables['users']} 
-             WHERE UPPER(last_name) = %s 
-             AND UPPER(email) = %s
-             AND phone_number = %s
+             WHERE blind_index = %s
              AND user_type = 'senior'",
-            $last_name,
-            $email,
-            $phone_number
+            $blind_index
         ));
 
         //No user with matching info found

--- a/quiz-plugin.php
+++ b/quiz-plugin.php
@@ -299,7 +299,7 @@ function display_recommendations_function($atts) {
     return ob_get_clean();
 }
 
-//This function handles the search previous user quizzes functionality. Users input their email, last name, phone number, and possibly password to see a 
+//This function handles the search previous user quizzes functionality. Users input their email, last name, phone number, and password to see a 
 //populated table of their previous quiz results
 function handle_quiz_search() {
     //check_ajax_referer('quiz_ajax_nonce', 'nonce');

--- a/temp_encryption_files/blind_index_keygen.php
+++ b/temp_encryption_files/blind_index_keygen.php
@@ -1,0 +1,6 @@
+<?php
+$new_key = random_bytes(SODIUM_CRYPTO_SECRETBOX_KEYBYTES);
+
+$encoded_key_for_storage = sodium_bin2base64($new_key, SODIUM_BASE64_VARIANT_ORIGINAL);
+
+echo $encoded_key_for_storage;

--- a/temp_encryption_files/db_decrypt_script.php
+++ b/temp_encryption_files/db_decrypt_script.php
@@ -1,0 +1,58 @@
+<?php
+require_once 'wp-load.php';
+$encryption_key_path = PRIVATE_KEY_FILE;
+
+if (!file_exists($encryption_key_path)) {
+    exit('Error: Key file not found at ' . $encryption_key_path);
+}
+
+$encryption_key_b64 = trim(file_get_contents($encryption_key_path));
+$encryption_key = sodium_base642bin($encryption_key_b64, SODIUM_BASE64_VARIANT_ORIGINAL);
+
+function decrypt_current_db(string $encrypted_field): string|false {
+    global $encryption_key;
+    $decoded_field = sodium_base642bin($encrypted_field, SODIUM_BASE64_VARIANT_ORIGINAL);
+    $nonce = mb_substr($decoded_field, 0, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES, '8bit');
+    $encrypted_text = mb_substr($decoded_field, SODIUM_CRYPTO_SECRETBOX_NONCEBYTES, null, '8bit');
+    $field_text = sodium_crypto_secretbox_open($encrypted_text, $nonce, $encryption_key);
+
+    sodium_memzero($nonce);
+
+    return $field_text;
+}
+
+set_time_limit(0);
+
+global $wpdb;
+$table_name = "wp_quizUsers";
+echo "Starting decryption process\n";
+
+$entries = $wpdb->get_results("SELECT user_id, first_name, last_name, email, phone_number, gender, province FROM {$table_name} WHERE blind_index IS NOT NULL OR blind_index != ''");
+if ($entries) {
+    foreach ($entries as $entry) {
+        // Save decrypted data
+        $decrypted_first_name = decrypt_current_db((string)$entry->first_name);
+        $decrypted_last_name = decrypt_current_db((string)$entry->last_name);
+        $decrypted_email = decrypt_current_db((string)$entry->email);
+        $decrypted_phone_number = decrypt_current_db((string)$entry->phone_number);
+        $decrypted_gender = decrypt_current_db((string)$entry->gender);
+        $decrypted_province = decrypt_current_db((string)$entry->province);
+        $wpdb->update(
+            $table_name,
+            array(
+                'first_name' => $decrypted_first_name,
+                'last_name' => $decrypted_last_name,
+                'email' => $decrypted_email,
+                'phone_number' => $decrypted_phone_number,
+                'gender' => $decrypted_gender,
+                'province' => $decrypted_province,
+                'blind_index' => ''
+            ),
+            array('user_id' => $entry->user_id)
+        );
+        echo "\nDecrypted user_id: " . $entry->user_id;
+    }
+}
+
+sodium_memzero($encryption_key);
+echo "\nDecryption complete\n";

--- a/temp_encryption_files/db_encrypt_script.php
+++ b/temp_encryption_files/db_encrypt_script.php
@@ -1,0 +1,82 @@
+<?php
+require_once 'wp-load.php';
+$encryption_key_path = PRIVATE_KEY_FILE;
+$blind_index_key_path = BLIND_INDEX_KEY_FILE;
+if (!file_exists($encryption_key_path)) {
+    exit('Error: Key file not found at ' . $encryption_key_path);
+}
+if (!file_exists($blind_index_key_path)) {
+    exit('Error: Blind index key file not found at ' . $blind_index_key_path);
+}
+
+$encryption_key_b64 = trim(file_get_contents($encryption_key_path));
+$encryption_key = sodium_base642bin($encryption_key_b64, SODIUM_BASE64_VARIANT_ORIGINAL);
+
+$blind_index_key_b64 = trim(file_get_contents($blind_index_key_path));
+$blind_index_key = sodium_base642bin($blind_index_key_b64, SODIUM_BASE64_VARIANT_ORIGINAL);
+
+function current_db_blind_index(string $email, string $last_name, string $phone_number): string|false {
+    global $blind_index_key;
+    $combined = $email . $last_name . $phone_number;
+
+    $blind_index = hash_hmac('sha256', $combined, $blind_index_key, true);
+    $blind_index_b64 = sodium_bin2base64($blind_index, SODIUM_BASE64_VARIANT_ORIGINAL);
+
+    sodium_memzero($combined);
+    sodium_memzero($email);
+    sodium_memzero($last_name);
+    sodium_memzero($phone_number);
+
+    return $blind_index_b64;
+}
+
+function encrypt_current_db(string $field): string|false {
+    global $encryption_key;
+    $nonce = random_bytes(SODIUM_CRYPTO_SECRETBOX_NONCEBYTES);
+    $encrypted = sodium_crypto_secretbox($field, $nonce, $encryption_key);
+    $result = sodium_bin2base64($nonce . $encrypted, SODIUM_BASE64_VARIANT_ORIGINAL);
+
+    sodium_memzero($nonce);
+    sodium_memzero($field);
+    return $result;
+}
+
+set_time_limit(0);
+
+global $wpdb;
+$table_name = "wp_quizUsers";
+echo "Starting encryption process\n";
+
+$entries = $wpdb->get_results("SELECT user_id, first_name, last_name, email, phone_number, gender, province FROM {$table_name} WHERE blind_index IS NULL OR blind_index = ''");
+if ($entries) {
+    foreach ($entries as $entry) {
+        // Save blind index
+        $current_entry_blind_index = current_db_blind_index((string)$entry->email, (string)$entry->last_name, (string)$entry->phone_number);
+
+        // Save encrypted data
+        $encrypted_first_name = encrypt_current_db((string)$entry->first_name);
+        $encrypted_last_name = encrypt_current_db((string)$entry->last_name);
+        $encrypted_email = encrypt_current_db((string)$entry->email);
+        $encrypted_phone_number = encrypt_current_db((string)$entry->phone_number);
+        $encrypted_gender = encrypt_current_db((string)$entry->gender);
+        $encrypted_province = encrypt_current_db((string)$entry->province);
+        $wpdb->update(
+            $table_name,
+            array(
+                'first_name' => $encrypted_first_name,
+                'last_name' => $encrypted_last_name,
+                'email' => $encrypted_email,
+                'phone_number' => $encrypted_phone_number,
+                'gender' => $encrypted_gender,
+                'province' => $encrypted_province,
+                'blind_index' => $current_entry_blind_index
+            ),
+            array('user_id' => $entry->user_id)
+        );
+	echo "\nEncrypted user_id: " . $entry->user_id;
+    }
+}
+
+sodium_memzero($encryption_key);
+sodium_memzero($blind_index_key);
+echo "\nEncryption complete\n";

--- a/temp_encryption_files/encryption_keygen.php
+++ b/temp_encryption_files/encryption_keygen.php
@@ -1,0 +1,6 @@
+<?php
+$new_key = sodium_crypto_secretbox_keygen();
+
+$encoded_key_for_storage = sodium_bin2base64($new_key, SODIUM_BASE64_VARIANT_ORIGINAL);
+
+echo $encoded_key_for_storage;


### PR DESCRIPTION
The encryption is done using a PHP library called Sodium. Using that same library, an encryption key can be generated with a script:

```
<?php
$new_key = sodium_crypto_secretbox_keygen();

$encoded_key_for_storage = sodium_bin2base64($new_key, SODIUM_BASE64_VARIANT_ORIGINAL);

echo $encoded_key_for_storage;
```

The key can then be put into a .key file in htdocs. This file's permissions should be set to 400 (or 600 if it ever needs to be edited. IMPORTANT: DO NOT CHANGE OR REMOVE KEYS WHILE DATA IS ENCRYPTED. If you ever need to change the key, decrypt the database first, then change the key and re-encrypt it.). Then, a global variable with the path to the key file can be added to wp-config.php, like:

`define( 'PRIVATE_KEY_FILE', dirname( __FILE__ ) . '/private_key.key' );`

All of this setup can be seen currently on the staging site. The actual site functionality was added to the Quiz_Handler class. The quiz_encrypt_data method uses the key and a Sodium function to encrypt a piece of data, which is then used in save_responses for each field. The encrypted data and keys are base64 encoded before storage in the database/a file, to avoid any issues with storing weird binary characters. There is also a decryption function, but it isn't used for anything right now. It could be used in the future for a user to view/edit their information.

For quiz searching, there will be a new column in wp_quizUsers called blind_index. Since the search inputs are just normal plaintext, and the relevant fields are encrypted, without this column we would have to decrypt every field every time and compare it to the search input. The blind index hashes the combination of the email, last name, and phone number (the three search fields) and stores it for each user. This way, we can compare it with the new search hash without decrypting any information. Blind index generation requires a separate key, which can be generated with:

```
<?php
$new_key = random_bytes(SODIUM_CRYPTO_SECRETBOX_KEYBYTES);

$encoded_key_for_storage = sodium_bin2base64($new_key, SODIUM_BASE64_VARIANT_ORIGINAL);

echo $encoded_key_for_storage;
```

It can then be put in a .key file in the same way as above. The new column "blind_index" should also be added to the wp_quizUsers table through phpMyAdmin. Once this is set up, newly-saved user information will be encrypted. To encrypt current data, there is a one-time script, db_encrypt_script.php. It can be used by ssh-ing into the site and running "php db_encrypt_script.php" from within the proper directory. After key generation and database encryption, temp_encryption_files can be deleted. There is also a database decryption script (just in case), but none of these files should be needed again.